### PR TITLE
More commands listed in README and refactored method in ReferenceService

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Testikattavuusraportin saa luotua komennolla
 poetry run invoke coverage-report
 ```
 
+Robottitestit voi ajaa komennolla
+```
+poetry run robot src
+```
+
 Pylintin voi suorittaa komennolla
 ```
 poetry run invoke lint

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Käynnistä sovellus komennolla
 poetry run invoke start
 ```
 
+## Muita komentoja
+
+Testit voi ajaa komennolla
+```
+poetry run invoke test
+```
+
+Testikattavuusraportin saa luotua komennolla
+```
+poetry run invoke coverage-report
+```
+
+Pylintin voi suorittaa komennolla
+```
+poetry run invoke lint
+```
+
 ## Sovelluksen rakenne
 
 Paketoidaan sovelluksen toimintalogiikka

--- a/src/services/reference_service.py
+++ b/src/services/reference_service.py
@@ -30,15 +30,17 @@ class ReferenceService:
         references = self.reference_repository.get_all()
         return references
 
+    def citekey_is_available(self, citekey):
+        return self.reference_repository.citekey_is_available(citekey)
+
     def check_data_validity(self, field, user_input):
         if not user_input:
             return 'Input required'
 
         if field == 'citekey':
-            all_references = self.get_all_references()
-            for reference in all_references:
-                if user_input == reference['citekey']:
-                    return 'Citekey taken'
+            result = self.citekey_is_available(user_input)
+            if not result:
+                return 'Citekey taken'
 
         if field == 'author':
             if any(char.isdigit() for char in user_input):


### PR DESCRIPTION
Lisäsin README.md-tiedostoon listan käytettävissä olevista komennoista. Lisäksi muokkasin ReferenceServicen metodia check_data_validity niin, että se ei citekeytä tarkistaessaan käy suotta läpi kaikkia viitteitä, vaan kysyy tilanteen suoraan tietokannalta repositorion kautta.